### PR TITLE
Update link to use .org domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # fcc-github-syncing-service
-A prototype for a service freeCodeCamp can use to sync camper progress between GitHub and freeCodeCamp.com
+A prototype for a service freeCodeCamp can use to sync camper progress between GitHub and freeCodeCamp.org
 
 ## Proposal
 


### PR DESCRIPTION
This pull request updates the link to use the .org domain name.